### PR TITLE
Circumvent IBGateway connection Bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER clifton <cliftonk@gmail.com>
 
 # install xvfb and other X dependencies for IB
 RUN apt-get update -y \
-    && apt-get install -y xvfb libxrender1 libxtst6 x11vnc \
+    && apt-get install -y xvfb libxrender1 libxtst6 x11vnc socat \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
@@ -25,8 +25,8 @@ ADD bin/run-gateway /usr/bin/run-gateway
 # set your own password to launch vnc
 # ENV VNC_PASSWORD doughnuts
 
-# 5900 for VNC, 4001 for the gateway API
-EXPOSE 5900 4001
+# 5900 for VNC, 4003 for the gateway API via socat
+EXPOSE 5900 4003
 
 ENV DISPLAY :0
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ Docker container that launches the Interactive Brokers Gateway GUI inside of an 
 ## Usage
 
     docker pull clifton/ib-gateway
-    docker run -e VNC_PASSWORD=mypass -p 5900:5900 -p 4001:4001 -i -t clifton/ib-gateway
+    docker run -e VNC_PASSWORD=mypass -p 5900:5900 -p 4003:4003 -d clifton/ib-gateway
 
-At this point, you should be able to connect with VNC and log in to the gateway. Once logged in, port 4001 will be open for you to make API calls against.
+Please make sure to select socket port 4001 and uncheck "Allow connections from localhost only" in the IB Gateway settings.
+At this point, you should be able to connect with VNC and log in to the gateway. Once logged in, port 4003 will be open for you to make API calls against.
 
 ## Contributing
 

--- a/bin/run-gateway
+++ b/bin/run-gateway
@@ -1,5 +1,6 @@
 #!/bin/bash
 cd /ib-gateway
+socat TCP-LISTEN:4003, fork TCP:127.0.0.1:4001&
 xvfb-daemon-run \
   java -cp jts.jar:total.jar \
   -Dsun.java2d.noddraw=true \

--- a/init/xvfb_init
+++ b/init/xvfb_init
@@ -1,6 +1,6 @@
 #!/bin/bash
 XVFB=/usr/bin/Xvfb
-XVFBARGS="$DISPLAY -ac -screen 0 800x600x16 +extension RANDR"
+XVFBARGS="$DISPLAY -ac -screen 0 1280x800x16 +extension RANDR"
 PIDFILE=/var/xvfb_${DISPLAY:1}.pid
 
 case "$1" in


### PR DESCRIPTION
I tried everything to get the image working, but it was not possible to establish a connection to IB Gateway from the outside or from another container (running docker on Ubuntu 14.04, everything else untouched).

I dont seem to be the only one with that problem:
http://blog.charmes.net/2014/11/orchestrate-docker-locally-with.html

The socat "hack" fixes the problem. Additionally i changed the resolution to 1280x800, I was not able to change IB Gateway settings with 800x600 without crashing xvfb.

Probably the Readme should be extended to explain easy connection to other docker containers (via --link), in this case you dont even need to expose port 4003/4001 to the outside.
